### PR TITLE
Specify Yarn as package manager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
   "keywords": [
     "alphanumeric",
     "compare"
-  ]
+  ],
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
Added the 'packageManager' field to indicate usage of Yarn version 1.22.19 for managing dependencies.